### PR TITLE
%YAML directive parsing is broken

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
+++ b/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
@@ -590,7 +590,7 @@ public class Tokenizer {
 		String minor = scanYamlDirectiveNumber();
 		if (NULL_BL_LINEBR.indexOf(peek()) == -1)
 			throw new TokenizerException("While scanning for a directive value, expected a digit or '.' but found: " + ch(peek()));
-		return major + " " + minor;
+		return major + "." + minor;
 	}
 
 	private String scanYamlDirectiveNumber () {


### PR DESCRIPTION
YAML directive value is parsed as "MAJOR MINOR" but Version expects dot-separated String
