### PR TITLE
Add support for try-with-resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<!-- default encoding -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<java.version>1.5</java.version>
+		<java.version>1.7</java.version>
 	</properties>
 
 	<build>

--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -16,17 +16,11 @@
 
 package com.esotericsoftware.yamlbeans;
 
-import static com.esotericsoftware.yamlbeans.parser.EventType.*;
-
-import com.esotericsoftware.yamlbeans.Beans.Property;
-import com.esotericsoftware.yamlbeans.parser.AliasEvent;
-import com.esotericsoftware.yamlbeans.parser.CollectionStartEvent;
-import com.esotericsoftware.yamlbeans.parser.Event;
-import com.esotericsoftware.yamlbeans.parser.Parser;
-import com.esotericsoftware.yamlbeans.parser.Parser.ParserException;
-import com.esotericsoftware.yamlbeans.parser.ScalarEvent;
-import com.esotericsoftware.yamlbeans.scalar.ScalarSerializer;
-import com.esotericsoftware.yamlbeans.tokenizer.Tokenizer.TokenizerException;
+import static com.esotericsoftware.yamlbeans.parser.EventType.DOCUMENT_START;
+import static com.esotericsoftware.yamlbeans.parser.EventType.MAPPING_END;
+import static com.esotericsoftware.yamlbeans.parser.EventType.SCALAR;
+import static com.esotericsoftware.yamlbeans.parser.EventType.SEQUENCE_END;
+import static com.esotericsoftware.yamlbeans.parser.EventType.STREAM_END;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -40,9 +34,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.esotericsoftware.yamlbeans.Beans.Property;
+import com.esotericsoftware.yamlbeans.parser.AliasEvent;
+import com.esotericsoftware.yamlbeans.parser.CollectionStartEvent;
+import com.esotericsoftware.yamlbeans.parser.Event;
+import com.esotericsoftware.yamlbeans.parser.Parser;
+import com.esotericsoftware.yamlbeans.parser.Parser.ParserException;
+import com.esotericsoftware.yamlbeans.parser.ScalarEvent;
+import com.esotericsoftware.yamlbeans.scalar.ScalarSerializer;
+import com.esotericsoftware.yamlbeans.tokenizer.Tokenizer.TokenizerException;
+
 /** Deserializes Java objects from YAML.
  * @author <a href="mailto:misc@n4te.com">Nathan Sweet</a> */
-public class YamlReader {
+public class YamlReader implements AutoCloseable {
 	private final YamlConfig config;
 	Parser parser;
 	private final Map<String, Object> anchors = new HashMap();
@@ -72,7 +76,8 @@ public class YamlReader {
 	public Object get (String alias) {
 		return anchors.get(alias);
 	}
-
+	
+	@Override
 	public void close () throws IOException {
 		parser.close();
 		anchors.clear();

--- a/src/com/esotericsoftware/yamlbeans/YamlWriter.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlWriter.java
@@ -45,7 +45,7 @@ import com.esotericsoftware.yamlbeans.scalar.ScalarSerializer;
 
 /** Serializes Java objects as YAML.
  * @author <a href="mailto:misc@n4te.com">Nathan Sweet</a> */
-public class YamlWriter {
+public class YamlWriter implements AutoCloseable {
 	private final YamlConfig config;
 	private final Emitter emitter;
 	private boolean started;
@@ -118,6 +118,7 @@ public class YamlWriter {
 
 	/** Finishes writing any buffered output and releases all resources.
 	 * @throws YamlException If the buffered output could not be written or the writer could not be closed. */
+	@Override
 	public void close () throws YamlException {
 		clearAnchors();
 		defaultValuePrototypes.clear();


### PR DESCRIPTION
In JDK 7, a new ["try-with-resources"](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) approach has been introduced, a finally block is no longer required. The file will be closed automatically after the try block.