### PR TITLE
removed System.out.println during parsing

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -344,7 +344,6 @@ public class YamlReader {
 		}
 		case SCALAR:
 			// Interpret an empty scalar as null.
-			System.out.println(((ScalarEvent)event).value);
 			if (((ScalarEvent)event).value.length() == 0) {
 				event = parser.getNextEvent();
 				return null;

--- a/src/com/esotericsoftware/yamlbeans/parser/Parser.java
+++ b/src/com/esotericsoftware/yamlbeans/parser/Parser.java
@@ -79,7 +79,6 @@ public class Parser {
 		while (!parseStack.isEmpty()) {
 			Event event = parseStack.remove(0).produce();
 			if (event != null) {
-				// System.out.println("Parser: " + event);
 				return event;
 			}
 		}

--- a/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
+++ b/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
@@ -133,7 +133,6 @@ public class Tokenizer {
 		if (!tokens.isEmpty()) {
 			tokensTaken++;
 			Token token = tokens.remove(0);
-			// System.out.println("Tokenizer: " + token);
 			return token;
 		}
 		return null;


### PR DESCRIPTION
A library shouldn't log to STDOUT via System.out.println(..).
This may lead to confusing results, for example by writing out empty lines during parsing of a duplicated '---'.