### PR TITLE
Implemented a PropertyNameConverter which allows a custom mapping between java field names and YAML property names to be configured

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/PropertyNameConverter.java
+++ b/src/com/esotericsoftware/yamlbeans/PropertyNameConverter.java
@@ -1,0 +1,19 @@
+package com.esotericsoftware.yamlbeans;
+
+import java.lang.reflect.Field;
+
+public interface PropertyNameConverter {
+
+    PropertyNameConverter DEFAULT = new DefaultPropertyNameConverter();
+
+    /**
+     * Converts the Java field name into the YAML representation
+     */
+    String convertFieldToPropertyName (Field field);
+
+    class DefaultPropertyNameConverter implements PropertyNameConverter {
+        public String convertFieldToPropertyName (Field field) {
+            return field.getName();
+        }
+    }
+}

--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -44,6 +44,7 @@ public class YamlConfig {
 	final Map<Class, ScalarSerializer> scalarSerializers = new IdentityHashMap();
 	final Map<Property, Class> propertyToElementType = new HashMap();
 	final Map<Property, Class> propertyToDefaultType = new HashMap();
+	PropertyNameConverter propertyNameConverter = PropertyNameConverter.DEFAULT;
 	boolean beanProperties = true;
 	boolean privateFields;
 	boolean privateConstructors = true;
@@ -74,7 +75,9 @@ public class YamlConfig {
 	}
 
 	/** Sets the default type of elements in a Collection or Map property. No tag will be output for elements of this type. This
-	 * type will be used for each element if no tag is found. */
+	 * type will be used for each element if no tag is found.
+	 * If a PropertyNameConverter is in use then propertyName should be in the converted format
+	 * */
 	public void setPropertyElementType (Class type, String propertyName, Class elementType) {
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
 		if (propertyName == null) throw new IllegalArgumentException("propertyName cannot be null.");
@@ -115,6 +118,12 @@ public class YamlConfig {
 	/** If true, private no-arg constructors will be used. Default is true. */
 	public void setPrivateConstructors (boolean privateConstructors) {
 		this.privateConstructors = privateConstructors;
+	}
+
+	/** Sets the strategy to use when converting between YAML property and Java field names.
+	 *  Default is no conversion. (Yaml properties will be matched to Java fields with the same name)*/
+	public void setPropertyNameConverter (PropertyNameConverter propertyNameConverter) {
+		this.propertyNameConverter = propertyNameConverter;
 	}
 
 	static public class WriteConfig {

--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -92,8 +92,10 @@ public class YamlConfig {
 		propertyToElementType.put(property, elementType);
 	}
 
-	/** Sets the default type of a property. No tag will be output for values of this type. This type will be used if no tag is
-	 * found. */
+	/** Sets the default type of a property. No tag will be output for values of this type.
+	 * This type will be used if no tag is found.
+	 * If a PropertyNameConverter is in use then propertyName should be in the converted format
+	 */
 	public void setPropertyDefaultType (Class type, String propertyName, Class defaultType) {
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
 		if (propertyName == null) throw new IllegalArgumentException("propertyName cannot be null.");

--- a/src/com/esotericsoftware/yamlbeans/YamlWriter.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlWriter.java
@@ -262,7 +262,7 @@ public class YamlWriter {
 					if (propertyValue == null && prototypeValue == null) continue;
 					if (propertyValue != null && prototypeValue != null && prototypeValue.equals(propertyValue)) continue;
 				}
-				emitter.emit(new ScalarEvent(null, null, new boolean[] {true, true}, property.getName(), (char)0));
+				emitter.emit(new ScalarEvent(null, null, new boolean[] {true, true}, property.getConvertedName(), (char)0));
 				Class propertyElementType = config.propertyToElementType.get(property);
 				Class propertyDefaultType = config.propertyToDefaultType.get(property);
 				writeValue(propertyValue, property.getType(), propertyElementType, propertyDefaultType);

--- a/test/com/esotericsoftware/yamlbeans/TestPropertyNameConverter.java
+++ b/test/com/esotericsoftware/yamlbeans/TestPropertyNameConverter.java
@@ -1,0 +1,12 @@
+package com.esotericsoftware.yamlbeans;
+
+import java.lang.reflect.Field;
+
+/**
+ * Converts properties into upper case, for unit testing
+ */
+public class TestPropertyNameConverter implements PropertyNameConverter {
+    public String convertFieldToPropertyName (Field field) {
+        return field.getName().toUpperCase();
+    }
+}

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -16,6 +16,7 @@
 
 package com.esotericsoftware.yamlbeans;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -166,6 +167,21 @@ public class YamlReaderTest extends TestCase {
 		return new YamlReader(yaml).read(Test.class);
 	}
 
+	private Test readUpperCase (String yaml) throws Exception {
+		if (true) {
+			System.out.println(yaml);
+			System.out.println("===");
+			YamlReader reader = new YamlReader(yaml);
+			reader.getConfig().setPropertyNameConverter(new TestPropertyNameConverter());
+			System.out.println(reader.read(null));
+			System.out.println();
+			System.out.println();
+		}
+		YamlReader reader = new YamlReader(yaml);
+		reader.getConfig().setPropertyNameConverter(new TestPropertyNameConverter());
+		return reader.read(Test.class);
+	}
+
 	static public class Test {
 		public String stringValue;
 		public int intValue;
@@ -213,6 +229,97 @@ public class YamlReaderTest extends TestCase {
 		assertEquals(3, object.getX());
 		assertEquals(4, object.getY());
 		assertEquals(5, object.getZ());
+	}
+
+	public void testReadMap_WithPropertyNameConverter () throws Exception {
+		YamlConfig config = new YamlConfig();
+		config.setPropertyNameConverter(new TestPropertyNameConverter());
+		Map actual = (Map) new YamlReader("foo: bar\nbaz:\n buz: qux", config).read();
+
+		Map expected = new HashMap();
+		expected.put("foo", "bar");
+
+		Map expectedBaz = new HashMap();
+		expectedBaz.put("buz", "qux");
+		expected.put("baz", expectedBaz);
+
+		assertEquals(expected, actual);
+	}
+
+	public void testSimpleFields_WithPropertyNameConverter () throws Exception {
+		Test test = readUpperCase( //
+				"STRINGVALUE: moo\ufec9moo\n" + //
+						"INTVALUE: !!int 123\n" + //
+						"FLOATVALUE: 0.3\n" + //
+						"DOUBLEVALUE: 0.0002\n" + //
+						"LONGVALUE: 999999\n" + //
+						"SHORTVALUE: 125\n" + //
+						"CHARVALUE: j\n" + //
+						"TESTENUM: b\n" + //
+						"BYTEVALUE: 14" //
+		);
+
+		assertEquals("moo\ufec9moo", test.stringValue);
+		assertEquals(123, test.intValue);
+		assertEquals(0.3f, test.floatValue);
+		assertEquals(0.0002d, test.doubleValue);
+		assertEquals(999999, test.longValue);
+		assertEquals(125, test.shortValue);
+		assertEquals('j', test.charValue);
+		assertEquals(14, test.byteValue);
+		assertEquals(TestEnum.b, test.testEnum);
+
+		assertEquals(true, readUpperCase("BOOLEANVALUE: true").booleanValue);
+		assertEquals(false, readUpperCase("BOOLEANVALUE: 123").booleanValue);
+		assertEquals(false, readUpperCase("BOOLEANVALUE: 0").booleanValue);
+		assertEquals(false, readUpperCase("BOOLEANVALUE: false").booleanValue);
+	}
+
+	public void testSequence_WithPropertyNameConverter () throws Exception {
+		Test test = readUpperCase("LISTVALUES: [moo, 2]");
+		assertEquals(2, test.listValues.size());
+		assertEquals("moo", test.listValues.get(0));
+		assertEquals("2", test.listValues.get(1));
+
+		test = readUpperCase("ARRAYOBJECTS: [moo, 2]");
+		assertEquals(2, test.arrayObjects.length);
+		assertEquals("moo", test.arrayObjects[0]);
+		assertEquals("2", test.arrayObjects[1]);
+
+		test = readUpperCase("ARRAYSTRINGS: [moo, 2]");
+		assertEquals(2, test.arrayStrings.length);
+		assertEquals("moo", test.arrayStrings[0]);
+		assertEquals("2", test.arrayStrings[1]);
+
+		test = readUpperCase("ARRAYINTS: [34, 21]");
+		assertEquals(2, test.arrayInts.length);
+		assertEquals(34, test.arrayInts[0]);
+		assertEquals(21, test.arrayInts[1]);
+
+		test = readUpperCase("LISTVALUES:\n- moo\n- 2");
+		assertEquals(2, test.listValues.size());
+		assertEquals("moo", test.listValues.get(0));
+		assertEquals("2", test.listValues.get(1));
+
+		test = readUpperCase("LISTVALUES:\n  - moo\n  - 2");
+		assertEquals(2, test.listValues.size());
+		assertEquals("moo", test.listValues.get(0));
+		assertEquals("2", test.listValues.get(1));
+
+		test = readUpperCase("ARRAYOBJECTS:\n  - moo\n  - 2");
+		assertEquals(2, test.arrayObjects.length);
+		assertEquals("moo", test.arrayObjects[0]);
+		assertEquals("2", test.arrayObjects[1]);
+
+		test = readUpperCase("ARRAYSTRINGS:\n  - moo\n  - 2");
+		assertEquals(2, test.arrayStrings.length);
+		assertEquals("moo", test.arrayStrings[0]);
+		assertEquals("2", test.arrayStrings[1]);
+
+		test = readUpperCase("ARRAYINTS:\n  - 34\n  - 21");
+		assertEquals(2, test.arrayInts.length);
+		assertEquals(34, test.arrayInts[0]);
+		assertEquals(21, test.arrayInts[1]);
 	}
 
 	static public class Moo1 {


### PR DESCRIPTION
Sometimes there is a difference between property names as they appear in YAML, and how the Java fields are named. This commit resolves that by introducing the concept of a `PropertyNameConverter` which allows the transformation between a Field and the YAML property to be defined.

The `PropertyNameConverter` can be defined using `YamlConfig.setPropertyNameConverter()`

There is a default implementation `DefaultPropertyNameConverter` which retains the existing functionality if nothing has been configured.

One notable difference is within `YamlConfig.setPropertyElementType` and `setPropertyDefaultType`. Here the `propertyName` parameter should be the YAML version of the name (the result of the conversion), not the field name.

Below is a short example which demonstrates mapping YAML properties containing spaces, onto camel case field names. eg. `full name` becomes `fullName`.

```
package com.esotericsoftware.yamlbeans;

import java.io.StringWriter;
import java.lang.reflect.Field;

public class PropertyNameConverterExample {

    private static final PropertyNameConverter CAMELCASE_TO_SPACES_CONVERTER = new PropertyNameConverter() {
        public String convertFieldToPropertyName(Field field) {
            return field.getName().replaceAll("[A-Z]", " $0").trim().toLowerCase();
        }
    };

    public static void main(String[] args) throws YamlException {
        TestObject o = new TestObject();
        o.setFullName("Bob");
        o.setPhoneNumber("124-1234-324");

        StringWriter sw = new StringWriter();
        YamlWriter writer = new YamlWriter(sw);
        writer.getConfig().setPropertyNameConverter(CAMELCASE_TO_SPACES_CONVERTER);
        writer.write(o);
        writer.close();

        System.out.println(sw);

        YamlReader reader = new YamlReader(sw.toString());
        reader.getConfig().setPropertyNameConverter(CAMELCASE_TO_SPACES_CONVERTER);
        TestObject o2 = reader.read(TestObject.class);
        System.out.println("o2.getFullName() = " + o2.getFullName());
        System.out.println("o2.getPhoneNumber() = " + o2.getPhoneNumber());

    }

    public static class TestObject {
        private String fullName;
        private String phoneNumber;

        public String getFullName() {
            return fullName;
        }

        public void setFullName(String fullName) {
            this.fullName = fullName;
        }

        public String getPhoneNumber() {
            return phoneNumber;
        }

        public void setPhoneNumber(String phoneNumber) {
            this.phoneNumber = phoneNumber;
        }
    }
}
```

Output:
```
!com.esotericsoftware.yamlbeans.PropertyNameConverterExample$TestObject
full name: Bob
phone number: 124-1234-324

o2.getFullName() = Bob
o2.getPhoneNumber() = 124-1234-324
```