### PR TITLE
Added support for boolean properties with is<PropertyName> pattern

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/Beans.java
+++ b/src/com/esotericsoftware/yamlbeans/Beans.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import com.esotericsoftware.yamlbeans.YamlConfig.ConstructorParameters;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 
 /** Utility for dealing with beans and public fields.
  * @author <a href="mailto:misc@n4te.com">Nathan Sweet</a> */
@@ -129,6 +130,12 @@ class Beans {
 					getMethod = type.getMethod("get" + nameUpper, noArgs);
 				} catch (Exception ignored) {
 				}
+				if (getMethod == null && (field.getType().equals(Boolean.class) || field.getType().equals(boolean.class))) {
+					try {
+						getMethod = type.getMethod("is" + nameUpper, noArgs);
+					} catch (Exception ignored) {
+					}
+				}
 				if (getMethod != null && (setMethod != null || constructorProperty)) {
 					properties.add(new MethodProperty(name, setMethod, getMethod));
 					continue;
@@ -167,6 +174,12 @@ class Beans {
 				try {
 					getMethod = type.getMethod("get" + nameUpper, noArgs);
 				} catch (Exception ignored) {
+				}
+				if (getMethod == null && (field.getType().equals(Boolean.class) || field.getType().equals(boolean.class))) {
+					try {
+						getMethod = type.getMethod("is" + nameUpper, noArgs);
+					} catch (Exception ignored) {
+					}
 				}
 				if (getMethod != null && (setMethod != null || constructorProperty))
 					return new MethodProperty(name, setMethod, getMethod);

--- a/src/com/esotericsoftware/yamlbeans/Beans.java
+++ b/src/com/esotericsoftware/yamlbeans/Beans.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import com.esotericsoftware.yamlbeans.YamlConfig.ConstructorParameters;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 
 /** Utility for dealing with beans and public fields.
  * @author <a href="mailto:misc@n4te.com">Nathan Sweet</a> */

--- a/test/com/esotericsoftware/yamlbeans/BooleanTest.java
+++ b/test/com/esotericsoftware/yamlbeans/BooleanTest.java
@@ -1,0 +1,78 @@
+package com.esotericsoftware.yamlbeans;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class BooleanTest extends TestCase {
+    public void testBooleanBean() throws Exception {
+        // Create a bean with a value differing from it's default
+        BeanWithBoolean val = new BeanWithBoolean();
+        val.setBool(true);
+        val.setBoolObj(true);
+
+        // Store the bean
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        YamlWriter yamlWriter = new YamlWriter(new OutputStreamWriter(out));
+        yamlWriter.write(val);
+        yamlWriter.close();
+
+        // Load the bean
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        YamlReader yamlReader = new YamlReader(new InputStreamReader(in));
+        BeanWithBoolean got = yamlReader.read(BeanWithBoolean.class);
+
+        assertEquals(val, got);
+    }
+
+    public static class BeanWithBoolean {
+        private boolean bool = false;
+        private Boolean boolObj = false;
+
+        public boolean isBool() {
+            return bool;
+        }
+
+        public void setBool(boolean bool) {
+            this.bool = bool;
+        }
+
+        public Boolean getBoolObj() {
+            return boolObj;
+        }
+
+        public void setBoolObj(Boolean boolObj) {
+            this.boolObj = boolObj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BeanWithBoolean that = (BeanWithBoolean) o;
+
+            if (bool != that.bool) return false;
+            return !(boolObj != null ? !boolObj.equals(that.boolObj) : that.boolObj != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (bool ? 1 : 0);
+            result = 31 * result + (boolObj != null ? boolObj.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "BeanWithBoolean{" +
+                    "bool=" + bool +
+                    ", boolObj=" + boolObj +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
Added support for boolean properties with is&lt;PropertyName> pattern. This is described in the JavaBeans spec § 8.3.2:

**8.3.2 Boolean properties**
In addition, for boolean properties, we allow a getter method to match the pattern:

```java
public boolean is<PropertyName>();
```

This “is<PropertyName>” method may be provided instead of a “get<PropertyName>” method, or it may be provided in addition to a “get<PropertyName>” method.

In either case, if the “is<PropertyName>” method is present for a boolean property then we will use the “is<PropertyName>” method to read the property value.

An example boolean property might be:

```java
public boolean isMarsupial();
public void setMarsupial(boolean m);
```