### PR TITLE
Add an option to allow unknown properties while deserializing an object.

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -210,6 +210,7 @@ public class YamlConfig {
 		Version defaultVersion = new Version(1, 1);
 		ClassLoader classLoader;
 		final Map<Class, ConstructorParameters> constructorParameters = new IdentityHashMap();
+		boolean allowUnknownProperties;
 
 		ReadConfig () {
 		}
@@ -240,6 +241,11 @@ public class YamlConfig {
 			}
 			parameters.parameterNames = parameterNames;
 			constructorParameters.put(type, parameters);
+		}
+
+		/** If true, unknown properties will be ignored instead of raising an exception while parsing. Default is false. */
+		public void setAllowUnknownProperties(boolean allowUnknownProperties) {
+			this.allowUnknownProperties = allowUnknownProperties;
 		}
 	}
 

--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -289,7 +289,10 @@ public class YamlReader {
 					try {
 						Property property = Beans.getProperty(type, (String)key, config.beanProperties, config.privateFields, config);
 						if (property == null)
-							throw new YamlReaderException("Unable to find property '" + key + "' on class: " + type.getName());
+							if (config.readConfig.allowUnknownProperties)
+								continue;
+							else
+								throw new YamlReaderException("Unable to find property '" + key + "' on class: " + type.getName());
 						Class propertyElementType = config.propertyToElementType.get(property);
 						if (propertyElementType == null)
 							propertyElementType = property.getElementType();

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -292,4 +292,30 @@ public class YamlReaderTest extends TestCase {
 			this.z = z;
 		}
 	}
+
+	static class ACD {
+		public int a, c, d = 4;
+	}
+
+	public void testAllowUnknownProperties() {
+		String input = "a: 1\nb: 2\nc: 3";
+		YamlConfig config = new YamlConfig();
+		try {
+			new YamlReader(input, config).read(ACD.class);
+			fail("Unknown properties were not supposed to be allowed.");
+		}
+		catch (YamlException e) {
+		}
+
+		config.readConfig.setAllowUnknownProperties(true);
+		try {
+			ACD pojo = new YamlReader(input, config).read(ACD.class);
+			assertEquals(1, pojo.a);
+			assertEquals(3, pojo.c);
+			assertEquals(4, pojo.d);
+		}
+		catch (YamlException e) {
+			fail("Unknown properties were supposed to be allowed.");
+		}
+	}
 }


### PR DESCRIPTION
Hi, this small contribution is to add an option to allow unknown properties while deserializing an object.

My use case: share a config file between multiple services. If I introduce a new property and deploy 1 service at a time for testing, older services will complain about the new property without this patch.

Please have a look at it and thanks for this handy library.