### PR TITLE
YamlReader was ignoring missing sequences

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -290,10 +290,13 @@ public class YamlReader {
 						Property property = Beans.getProperty(type, (String)key, config.beanProperties, config.privateFields, config);
 						if (property == null) {
 							if (config.readConfig.ignoreUnknownProperties) {
+								// go though the next event, because this is a value of missing property
+								Event nextEvent = parser.getNextEvent();
+								
 								// if next event is sequence start, go
-								// though all of it until corresponding
+								//though all of it until corresponding
 								// sequence end
-								if (parser.peekNextEvent().type == SEQUENCE_START) {
+								if (nextEvent.type == SEQUENCE_START) {
 									skipSequence();
 								}
 

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -159,7 +159,7 @@ public class YamlReaderTest extends TestCase {
 		if (true) {
 			System.out.println(yaml);
 			System.out.println("===");
-			System.out.println(new YamlReader(yaml).read(null));
+			System.out.println(new YamlReader(yaml).read(null).toString());
 			System.out.println();
 			System.out.println();
 		}

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -316,4 +316,27 @@ public class YamlReaderTest extends TestCase {
 			fail("Unknown properties were supposed to be allowed.");
 		}
 	}
+	
+	public void testIgnoreUnknownPropertiesSequences() throws Exception {
+		String input = "" +
+			"elements: \n" + 
+			"  - 1\n" +
+			"  - 2\n";
+
+		YamlConfig config = new YamlConfig();
+		try {
+			new YamlReader(input, config).read(ACD.class);
+			fail("Unknown properties were not supposed to be allowed.");
+		} catch (YamlException e) {
+		}
+
+		config.readConfig.setIgnoreUnknownProperties(true);
+		try {
+			ACD pojo = new YamlReader(input, config).read(ACD.class);
+		} catch (YamlException e) {
+			e.printStackTrace();
+			fail("Unknown properties were supposed to be allowed.");
+		}
+
+	}
 }


### PR DESCRIPTION
There's a ignoreUnknownProperties flag added quite recently. It does not handle sequences properly.

Sequence is created of several events. When the first SCALAR event is handled and the field for this field is missing, the later event (SEQUENCE_START) is trying to be parsed in an usual manner. As result we're receiving cast error, because we're expecting to get next field name as String, but there's an ArrayList instead.

My patch if checking after the ignore if next event is a SEQUENCE_START. If yes, it goes through all events until corresponding SEQUENCE_END is found.

Also I created a test for it.

P.S. I needed to add one toString() in 756779c to compile the tests. I'm not sure why (I'm using Java 9).
