### PR TITLE
WriteConfig option to keep bean field/properties order

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/Beans.java
+++ b/src/com/esotericsoftware/yamlbeans/Beans.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -111,7 +112,7 @@ class Beans {
 	static public Set<Property> getProperties (Class type, boolean beanProperties, boolean privateFields, YamlConfig config) {
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
 		Class[] noArgs = new Class[0], oneArg = new Class[1];
-		Set<Property> properties = new TreeSet();
+		Set<Property> properties = config.writeConfig.keepBeanPropertyOrder ? new LinkedHashSet() : new TreeSet();
 		for (Field field : getAllFields(type)) {
 			String name = field.getName();
 
@@ -202,11 +203,15 @@ class Beans {
 	}
 
 	static private ArrayList<Field> getAllFields (Class type) {
-		ArrayList<Field> allFields = new ArrayList();
+		ArrayList<Class> classes = new ArrayList();
 		Class nextClass = type;
 		while (nextClass != null && nextClass != Object.class) {
-			Collections.addAll(allFields, nextClass.getDeclaredFields());
+			classes.add(nextClass);
 			nextClass = nextClass.getSuperclass();
+		}
+		ArrayList<Field> allFields = new ArrayList();
+		for(int i = classes.size() - 1; i >= 0; i--) {
+			Collections.addAll(allFields, classes.get(i).getDeclaredFields());
 		}
 		return allFields;
 	}

--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -124,6 +124,7 @@ public class YamlConfig {
 		boolean writeRootTags = true;
 		boolean writeRootElementTags = true;
 		boolean autoAnchor = true;
+		boolean keepBeanPropertyOrder = false;
 		WriteClassName writeClassName = WriteClassName.AUTO;
 		EmitterConfig emitterConfig = new EmitterConfig();
 
@@ -168,6 +169,12 @@ public class YamlConfig {
 		 * {@link YamlWriter#clearAnchors()} should be called first to output any buffered objects. Default is true. */
 		public void setAutoAnchor (boolean autoAnchor) {
 			this.autoAnchor = autoAnchor;
+		}
+
+		/** If true, bean fields/properties are written in the same order as the fields are defined in the bean class.
+		 * If false, they are sorted alphabetically. Default is false. */ 
+		public void setKeepBeanPropertyOrder(boolean keepBeanPropertyOrder) {
+			this.keepBeanPropertyOrder = keepBeanPropertyOrder;
 		}
 
 		/** Sets the YAML version to output. Default is 1.1. */


### PR DESCRIPTION
This PR adds the option `keepBeanPropertyOrder` to WriteConfig to keep the bean field/properties order in the written YAML output. By default the bean properties are sorted alphabetically (as before).

E.g.:
```
public class MyBean {
  public String mm;
  public String zz;
  public String aa;
}
public class MyBean2 extends MyBean {
  public String nn;
  public String yy;
  public String bb;
}
```
With `keepBeanPropertyOrder = true` the output is:
```
!MyBean2
mm: M
zz: Z
aa: A
nn: N
yy: Y
bb: B
```
With `keepBeanPropertyOrder = false` (the default) the output is:
```
!MyBean2
aa: A
bb: B
mm: M
nn: N
yy: Y
zz: Z
```
