### PR TITLE
YamlReader maintains entry order when reading a map from yaml

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -34,10 +34,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 /** Deserializes Java objects from YAML.
@@ -200,7 +197,7 @@ public class YamlReader {
 			Event event = parser.peekNextEvent();
 			switch (event.type) {
 			case MAPPING_START:
-				type = HashMap.class;
+				type = LinkedHashMap.class;
 				break;
 			case SCALAR:
 				type = String.class;
@@ -430,4 +427,4 @@ public class YamlReader {
 		YamlReader reader = new YamlReader(new FileReader("test/test.yml"));
 		System.out.println(reader.read());
 	}
-}
+}

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -17,6 +17,7 @@
 package com.esotericsoftware.yamlbeans;
 
 import java.io.StringReader;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -154,6 +155,24 @@ public class YamlReaderTest extends TestCase {
 		assertTrue(root.right.parent == root);
 		assertTrue(root.right.left == null);
 		assertTrue(root.right.right == null);
+	}
+
+	public void testReaderMaintainsOrderWhenReadingMap() throws Exception {
+		YamlReader reader = new YamlReader("a: b\nkey1: value1\nc: d\n");
+		Map map = (Map)reader.read();
+		Iterator entrySetIterator = map.entrySet().iterator();
+
+		Map.Entry mapEntry = (Map.Entry)entrySetIterator.next();
+		assertEquals(mapEntry.getKey(), "a");
+		assertEquals(mapEntry.getValue(), "b");
+
+		mapEntry = (Map.Entry)entrySetIterator.next();
+		assertEquals(mapEntry.getKey(), "key1");
+		assertEquals(mapEntry.getValue(), "value1");
+
+		mapEntry = (Map.Entry)entrySetIterator.next();
+		assertEquals(mapEntry.getKey(), "c");
+		assertEquals(mapEntry.getValue(), "d");
 	}
 
 	private Test read (String yaml) throws Exception {
@@ -428,4 +447,4 @@ public class YamlReaderTest extends TestCase {
 		assertEquals(1, lake.fish.size());
 		assertEquals("Walleye", lake.fish.get(0).species);
 	}
-}
+}


### PR DESCRIPTION
Added test to verify map entries can be iterated in the same order as the yaml. Changed YamlReader to use LinkedHashMap instead of HashMap to represent the entries from the yaml.