### PR TITLE
The Explicit Block Mapping

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/emitter/Emitter.java
+++ b/src/com/esotericsoftware/yamlbeans/emitter/Emitter.java
@@ -478,7 +478,7 @@ public class Emitter {
 			length += analysis.scalar.length();
 		}
 
-		return length < 128
+		return length < 1024
 			&& (event.type == ALIAS || event.type == SCALAR && !analysis.empty && !analysis.multiline || checkEmptySequence() || checkEmptyMapping());
 	}
 


### PR DESCRIPTION
In the YAML Version 1.1 specification (http://yaml.org/spec/1.1/#id934537),for the Explicit Block Mapping,having the following specifications:
YAML allows the “?” character to be omitted for simple keys. Similarly to flow mapping, such a key is recognized by a following “:” character. Again, to avoid unbound lookahead in YAML processors, simple keys are restricted to a single line and must not span more than 1024 stream characters. Again, this limit is in terms of Unicode characters rather than stream octets, and includes the separation following the key, if any. 

I implement the  length of key < 1024