### PR TITLE
"test-merge.yml" was missing in some tests.

### DIFF
--- a/test/com/esotericsoftware/yamlbeans/MergeTest.java
+++ b/test/com/esotericsoftware/yamlbeans/MergeTest.java
@@ -1,5 +1,7 @@
 package com.esotericsoftware.yamlbeans;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -11,8 +13,8 @@ import static org.junit.Assert.*;
 public class MergeTest {
 
 	@Test
-	public void testMerge() throws YamlException {
-		InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream("test-merge.yml");
+	public void testMerge() throws FileNotFoundException, YamlException {
+		InputStream input = new FileInputStream("test/test-merge.yml");
 		Reader reader = new InputStreamReader(input);
 		Map data = new YamlReader(reader).read(Map.class);
 		Map stuff = (Map)data.get("merged");


### PR DESCRIPTION
During test execution under Windows the file "test-merge.yml" was expected to be in "target\test-classes" at least one time, which it isn't, so that test failed. All other tests seem to rely on the current working directory instead of the classloader and changing MergeTest to follow the same approach makes all tests succeed.