### PR TITLE
feature enhancement to allow single/double/No quotes

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -139,6 +139,7 @@ public class YamlConfig {
 		boolean autoAnchor = true;
 		boolean keepBeanPropertyOrder = false;
 		WriteClassName writeClassName = WriteClassName.AUTO;
+        QuoteCharEnum quoteChar         = QuoteCharEnum.SINGLEQUOTE;
 		EmitterConfig emitterConfig = new EmitterConfig();
 
 		WriteConfig () {
@@ -220,11 +221,26 @@ public class YamlConfig {
 			emitterConfig.setEscapeUnicode(escapeUnicode);
 		}
 
-		/** If true, class name tags will always be output. */
+		/** based on Ennumeration parameter, class name tags will be output. */
 		public void setWriteClassname (WriteClassName write) {
 			writeClassName = write;
 		}
-	}
+
+        /** define the quote character you'd like to use, when writing YAML output. */
+        public void setQuoteChar (QuoteCharEnum _qc) {
+            this.quoteChar = _qc;
+        }
+        
+        /** Utility function: primarily for use within YamlWriter, to get the quote-character */
+        public char getQuoteChar() {
+            switch (this.quoteChar ) {
+                case NONE:         return ' ';
+                case SINGLEQUOTE:  return '\'';
+                case DOUBLEQUOTE:  return '\"';
+                default: return '\'';
+            }
+        }
+    }
 
 	static public class ReadConfig {
 		Version defaultVersion = new Version(1, 1);
@@ -292,4 +308,9 @@ public class YamlConfig {
 	public static enum WriteClassName {
 		ALWAYS, NEVER, AUTO
 	}
+
+    public static enum QuoteCharEnum {
+        NONE, SINGLEQUOTE, DOUBLEQUOTE
+    }
+    
 }

--- a/src/com/esotericsoftware/yamlbeans/YamlWriter.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlWriter.java
@@ -151,7 +151,7 @@ public class YamlWriter {
 		if (unknownType) fieldClass = valueClass;
 
 		if (object instanceof Enum) {
-			emitter.emit(new ScalarEvent(null, null, new boolean[] {true, true}, ((Enum)object).name(), (char)0));
+            emitter.emit(new ScalarEvent(null, null, new boolean[] {true, true}, ((Enum)object).name(), this.config.writeConfig.getQuoteChar() ));
 			return;
 		}
 
@@ -203,7 +203,7 @@ public class YamlWriter {
 			if (valueClass == String.class) {
 				try {
 					Float.parseFloat(string);
-					style = '\'';
+					style = this.config.writeConfig.getQuoteChar(); // = '\'';
 				} catch (NumberFormatException ignored) {
 				}
 			}
@@ -240,7 +240,7 @@ public class YamlWriter {
 							char style = 0;
 							try {
 								Float.parseFloat(string);
-								style = '\'';
+								style = this.config.writeConfig.getQuoteChar(); // = '\'';
 							} catch (NumberFormatException ignored) {
 							}
 							writeValue(key, null, null, null);
@@ -291,7 +291,7 @@ public class YamlWriter {
 					if (propertyValue == null && prototypeValue == null) continue;
 					if (propertyValue != null && prototypeValue != null && prototypeValue.equals(propertyValue)) continue;
 				}
-				emitter.emit(new ScalarEvent(null, null, new boolean[] {true, true}, property.getName(), (char)0));
+				emitter.emit(new ScalarEvent(null, null, new boolean[] {true, true}, property.getName(), this.config.writeConfig.getQuoteChar() ));
 				Class propertyElementType = config.propertyToElementType.get(property);
 				Class propertyDefaultType = config.propertyToDefaultType.get(property);
 				writeValue(propertyValue, property.getType(), propertyElementType, propertyDefaultType);


### PR DESCRIPTION
When creating the YAML output (emitting), allow us to set which type of Quote is written (via the `YamlConfig.WriteConfig` class, which is in turn used by `YamlWriter`).
**Example**:
```
                YamlWriter writer = new YamlWriter( new FileWriter(.. ..) );
                writer.getConfig().writeConfig.setQuoteChar( YamlConfig.QuoteCharEnum.SINGLEQUOTE  );

```