### PR TITLE
Fix invalid characters (brackets) in Javadocs

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -211,7 +211,7 @@ public class YamlConfig {
 			emitterConfig.setWrapColumn(wrapColumn);
 		}
 
-		/** If false, tags will never be surrounded by angle brackets (eg, "!<java.util.LinkedList>"). Default is false. */
+		/** If false, tags will never be surrounded by angle brackets (eg, "!&lt;java.util.LinkedList&gt;"). Default is false. */
 		public void setUseVerbatimTags (boolean useVerbatimTags) {
 			emitterConfig.setUseVerbatimTags(useVerbatimTags);
 		}

--- a/src/com/esotericsoftware/yamlbeans/emitter/EmitterConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/emitter/EmitterConfig.java
@@ -50,7 +50,7 @@ public class EmitterConfig {
 		this.wrapColumn = wrapColumn;
 	}
 
-	/** If false, tags will never be surrounded by angle brackets (eg, "!<java.util.LinkedList>"). Default is true. */
+	/** If false, tags will never be surrounded by angle brackets (eg, "!&lt;java.util.LinkedList&gt;"). Default is true. */
 	public void setUseVerbatimTags (boolean useVerbatimTags) {
 		this.useVerbatimTags = useVerbatimTags;
 	}


### PR DESCRIPTION
Closes #119 (but only the errors, not the warns)
This ends up being cleaner anyway, as the only true errors were the use of brackets (`<` and `>`) instead of `&lt;` and `&gt;` in two lines.