### PR TITLE
improve Beans.class, repeated code integration

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/Beans.java
+++ b/src/com/esotericsoftware/yamlbeans/Beans.java
@@ -112,46 +112,12 @@ class Beans {
 
 	static public Set<Property> getProperties (Class type, boolean beanProperties, boolean privateFields, YamlConfig config) {
 		if (type == null) throw new IllegalArgumentException("type cannot be null.");
-		Class[] noArgs = new Class[0], oneArg = new Class[1];
 		Set<Property> properties = config.writeConfig.keepBeanPropertyOrder ? new LinkedHashSet() : new TreeSet();
 		for (Field field : getAllFields(type)) {
-			String name = field.getName();
-
-			if (beanProperties) {
-				DeferredConstruction deferredConstruction = getDeferredConstruction(type, config);
-				boolean constructorProperty = deferredConstruction != null && deferredConstruction.hasParameter(name);
-
-				String nameUpper = Character.toUpperCase(name.charAt(0)) + name.substring(1);
-				Method getMethod = null, setMethod = null;
-				try {
-					oneArg[0] = field.getType();
-					setMethod = type.getMethod("set" + nameUpper, oneArg);
-				} catch (Exception ignored) {
-				}
-				try {
-					getMethod = type.getMethod("get" + nameUpper, noArgs);
-				} catch (Exception ignored) {
-				}
-				if (getMethod == null && (field.getType().equals(Boolean.class) || field.getType().equals(boolean.class))) {
-					try {
-						getMethod = type.getMethod("is" + nameUpper, noArgs);
-					} catch (Exception ignored) {
-					}
-				}
-				if (getMethod != null && (setMethod != null || constructorProperty)) {
-					properties.add(new MethodProperty(name, setMethod, getMethod));
-					continue;
-				}
+			Property property = getProperty(type, beanProperties, privateFields, config, field);
+			if (property != null) {
+				properties.add(property);
 			}
-
-			int modifiers = field.getModifiers();
-			if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) continue;
-			if (!Modifier.isPublic(modifiers) && !privateFields) continue;
-			try {
-				field.setAccessible(true);
-			} catch (Exception ignored) {
-			}
-			properties.add(new FieldProperty(field));
 		}
 		return properties;
 	}
@@ -171,47 +137,64 @@ class Beans {
 		if (name == null || name.length() == 0) throw new IllegalArgumentException("name cannot be null or empty.");
 		name = toJavaIdentifier(name);
 
+		Property property = null;
+		for (Field field : getAllFields(type)) {
+			if (field.getName().equals(name)) {
+				property = getProperty(type, beanProperties, privateFields, config, field);
+				break;
+			}
+		}
+		return property;
+	}
+
+	private static Property getProperty(Class<?> type, boolean beanProperties, boolean privateFields, YamlConfig config,
+			Field field) {
+		Property property = null;
 		if (beanProperties) {
+			String name = field.getName();
 			DeferredConstruction deferredConstruction = getDeferredConstruction(type, config);
 			boolean constructorProperty = deferredConstruction != null && deferredConstruction.hasParameter(name);
 
 			String nameUpper = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+			String setMethodName = "set" + nameUpper;
+			String getMethodName = "get" + nameUpper;
+			if (field.getType().equals(Boolean.class) || field.getType().equals(boolean.class)) {
+				setMethodName = name.startsWith("is")
+						? "set" + Character.toUpperCase(name.charAt(2)) + name.substring(3)
+						: setMethodName;
+				getMethodName = name.startsWith("is") ? name : "is" + nameUpper;
+			}
+
 			Method getMethod = null;
+			Method setMethod = null;
 			try {
-				getMethod = type.getMethod("get" + nameUpper);
+				setMethod = type.getMethod(setMethodName, field.getType());
 			} catch (Exception ignored) {
 			}
-			if (getMethod == null) {
+			try {
+				getMethod = type.getMethod(getMethodName);
+			} catch (Exception ignored) {
+			}
+
+			// field.getType() is boolean, but getMethodName is getFieldName(E.g: getBool).
+			if (getMethod == null && (field.getType().equals(Boolean.class) || field.getType().equals(boolean.class))) {
 				try {
-					getMethod = type.getMethod("is" + nameUpper);
+					getMethod = type.getMethod("get" + nameUpper);
 				} catch (Exception ignored) {
 				}
 			}
-			if (getMethod != null) {
-				Method setMethod = null;
-				try {
-					setMethod = type.getMethod("set" + nameUpper, getMethod.getReturnType());
-				} catch (Exception ignored) {
-				}
-				if (getMethod != null && (setMethod != null || constructorProperty))
-					return new MethodProperty(name, setMethod, getMethod);
+			if (getMethod != null && (setMethod != null || constructorProperty)) {
+				property = new MethodProperty(name, setMethod, getMethod);
 			}
 		}
 
-		for (Field field : getAllFields(type)) {
-			if (!field.getName().equals(name)) continue;
-			int modifiers = field.getModifiers();
-			if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) continue;
-			if (!Modifier.isPublic(modifiers) && !privateFields) continue;
-			try {
-				field.setAccessible(true);
-			} catch (Exception ignored) {
-			}
-			return new FieldProperty(field);
+		int modifiers = field.getModifiers();
+		if (!Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers)
+				&& (Modifier.isPublic(modifiers) || privateFields)) {
+			field.setAccessible(true);
+			property = new FieldProperty(field);
 		}
-
-		if (!name.startsWith("_")) return getProperty(type, "_" + name, beanProperties, privateFields, config);
-		return null;
+		return property;
 	}
 
 	static private ArrayList<Field> getAllFields (Class type) {

--- a/test/com/esotericsoftware/yamlbeans/BooleanTest.java
+++ b/test/com/esotericsoftware/yamlbeans/BooleanTest.java
@@ -13,6 +13,7 @@ public class BooleanTest extends TestCase {
         BeanWithBoolean val = new BeanWithBoolean();
         val.setBool(true);
         val.setBoolObj(true);
+        val.setBoolean(true);
 
         // Store the bean
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -31,6 +32,7 @@ public class BooleanTest extends TestCase {
     public static class BeanWithBoolean {
         private boolean bool = false;
         private Boolean boolObj = false;
+        private boolean isBoolean = false;
 
         public boolean isBool() {
             return bool;
@@ -48,7 +50,15 @@ public class BooleanTest extends TestCase {
             this.boolObj = boolObj;
         }
 
-        @Override
+        public boolean isBoolean() {
+            return isBoolean;
+        }
+
+        public void setBoolean(boolean isBoolean) {
+            this.isBoolean = isBoolean;
+        }
+
+		@Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
@@ -56,6 +66,7 @@ public class BooleanTest extends TestCase {
             BeanWithBoolean that = (BeanWithBoolean) o;
 
             if (bool != that.bool) return false;
+            if (isBoolean != that.isBoolean) return false;
             return !(boolObj != null ? !boolObj.equals(that.boolObj) : that.boolObj != null);
 
         }
@@ -63,6 +74,7 @@ public class BooleanTest extends TestCase {
         @Override
         public int hashCode() {
             int result = (bool ? 1 : 0);
+            result += (isBoolean ? 2 : 0);
             result = 31 * result + (boolObj != null ? boolObj.hashCode() : 0);
             return result;
         }
@@ -72,6 +84,7 @@ public class BooleanTest extends TestCase {
             return "BeanWithBoolean{" +
                     "bool=" + bool +
                     ", boolObj=" + boolObj +
+                    ", isBoolean=" + isBoolean +
                     '}';
         }
     }


### PR DESCRIPTION
- Beans.class：There is duplicate code between Beans.getProperties and Beans.getProperty, the method of getting Field Property should be the same, and support serialization and deserialization of boolean type field (isBoolean) starting with "is".
- BooleanTest: Add field isBoolean.