### PR TITLE
resolves #34

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
+++ b/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
@@ -953,7 +953,8 @@ public class Tokenizer {
 	private String scanPlainSpaces () {
 		StringBuilder chunks = new StringBuilder();
 		int length = 0;
-		while (peek(length) == ' ')
+        // YAML recognizes two white space characters: space and tab.
+        while (peek(length) == ' ' || peek(length) == '\t')
 			length++;
 		String whitespaces = prefixForward(length);
 		// forward(length);

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -485,4 +485,24 @@ public class YamlReaderTest extends TestCase {
 		double moneyValue = (Double) result.get("money");
 		assertEquals(money, moneyValue);
 	}
+
+    /**
+     * issue #34
+     *
+     * @throws YamlException
+     */
+    public void testWhiteSpaceCharacters() throws YamlException {
+
+        String stringWithSpace = "test test";
+        YamlReader reader = new YamlReader(stringWithSpace);
+        assertEquals(stringWithSpace, reader.read(String.class));
+
+        String stringWithTab = "test\ttesttest";
+        reader = new YamlReader(stringWithTab);
+        assertEquals(stringWithTab, reader.read(String.class));
+
+        String stringWithSpaceAndTab = "test test\ttest \ttest";
+        reader = new YamlReader(stringWithSpaceAndTab);
+        assertEquals(stringWithSpaceAndTab, reader.read(String.class));
+    }
 }


### PR DESCRIPTION
[White Space Characters](https://yaml.org/spec/1.2/spec.html#id2775170)
YAML recognizes two white space characters: space and tab.