### PR TITLE
Add Iterator

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/document/YamlDocument.java
+++ b/src/com/esotericsoftware/yamlbeans/document/YamlDocument.java
@@ -1,5 +1,7 @@
 package com.esotericsoftware.yamlbeans.document;
 
+import java.util.Iterator;
+
 import com.esotericsoftware.yamlbeans.YamlException;
 
 public interface YamlDocument {
@@ -23,5 +25,7 @@ public interface YamlDocument {
 	void addElement(Number value) throws YamlException;
 	void addElement(String value) throws YamlException;
 	void addElement(YamlElement element) throws YamlException;
-	
+
+	Iterator iterator();
+
 }

--- a/src/com/esotericsoftware/yamlbeans/document/YamlMapping.java
+++ b/src/com/esotericsoftware/yamlbeans/document/YamlMapping.java
@@ -1,6 +1,7 @@
 package com.esotericsoftware.yamlbeans.document;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -140,5 +141,9 @@ public class YamlMapping extends YamlElement implements YamlDocument {
 
 	public void addElement(YamlElement element) throws YamlException {
 		throw new YamlException("Can only add element on sequence!");
+	}
+
+	public Iterator<YamlEntry> iterator() {
+		return entries.iterator();
 	}
 }

--- a/src/com/esotericsoftware/yamlbeans/document/YamlSequence.java
+++ b/src/com/esotericsoftware/yamlbeans/document/YamlSequence.java
@@ -1,6 +1,7 @@
 package com.esotericsoftware.yamlbeans.document;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -120,5 +121,7 @@ public class YamlSequence extends YamlElement implements YamlDocument {
 		elements.add(new YamlScalar(value));
 	}
 
-
+	public Iterator<YamlElement> iterator() {
+		return elements.iterator();
+	}
 }

--- a/test/com/esotericsoftware/yamlbeans/document/YamlDocumentTest.java
+++ b/test/com/esotericsoftware/yamlbeans/document/YamlDocumentTest.java
@@ -1,6 +1,7 @@
 package com.esotericsoftware.yamlbeans.document;
 
 import java.io.StringWriter;
+import java.util.Iterator;
 
 import org.junit.Test;
 
@@ -130,6 +131,41 @@ public class YamlDocumentTest extends TestCase  {
 		assertEquals("- 123\n", actual);
 	}
 
+	@Test
+	public void testYamlSequenceIterator() throws YamlException {
+		YamlDocument yaml = readDocument("- 111\n- 222\n");
+		Iterator<YamlScalar> iterator = yaml.iterator();
+		assertEquals(true, iterator.hasNext());
+		YamlScalar yamlScalar = iterator.next();
+		assertEquals("111", yamlScalar.getValue());
+		assertEquals(true, iterator.hasNext());
+		yamlScalar = iterator.next();
+		assertEquals("222", yamlScalar.getValue());
+		assertEquals(false, iterator.hasNext());
+		try {
+			iterator.next();
+			fail("Already read to the end.");
+		} catch (Exception e) {
+		}
+	}
+
+	@Test
+	public void testYamlMappingIterator() throws YamlException {
+		YamlDocument yaml = readDocument("name: Andi\nage: 18\n");
+		Iterator<YamlEntry> iterator = yaml.iterator();
+		assertEquals(true, iterator.hasNext());
+		YamlEntry yamlEntry = iterator.next();
+		assertEquals("Andi", ((YamlScalar) yamlEntry.getValue()).getValue());
+		assertEquals(true, iterator.hasNext());
+		yamlEntry = iterator.next();
+		assertEquals("18", ((YamlScalar) yamlEntry.getValue()).getValue());
+		assertEquals(false, iterator.hasNext());
+		try {
+			iterator.next();
+			fail("Already read to the end.");
+		} catch (Exception e) {
+		}
+	}
 
 	private YamlDocument readDocument(String yaml) throws YamlException {
 		YamlDocumentReader reader = new YamlDocumentReader(yaml);


### PR DESCRIPTION
`YamlMapping` 、 `YamlSequence` call `getEntry( index)`、`getElement(int item)`, both call LinkedList.get(item)，the traversal speed is slower in this way. 

Adding `Iterator` will increase the speed of traversing elements.