### PR TITLE
Support reading multiple documents, and adding test cases

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/document/YamlDocumentReader.java
+++ b/src/com/esotericsoftware/yamlbeans/document/YamlDocumentReader.java
@@ -67,15 +67,20 @@ public class YamlDocumentReader {
 	}
 
 	private YamlDocument readDocument() {
+		YamlDocument yamlDocument = null;
 		Event event = parser.peekNextEvent();
 		switch (event.type) {
-			case MAPPING_START:
-				return readMapping();
-			case SEQUENCE_START:
-				return readSequence();
-			default:
-				throw new IllegalStateException();
+		case MAPPING_START:
+			yamlDocument = readMapping();
+			break;
+		case SEQUENCE_START:
+			yamlDocument = readSequence();
+			break;
+		default:
+			throw new IllegalStateException();
 		}
+		parser.getNextEvent(); // consume it(DOCUMENT_END)
+		return yamlDocument;
 	}
 
 	private YamlMapping readMapping() {

--- a/test/com/esotericsoftware/yamlbeans/document/YamlDocumentTest.java
+++ b/test/com/esotericsoftware/yamlbeans/document/YamlDocumentTest.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 
 import org.junit.Test;
 
+import com.esotericsoftware.yamlbeans.Version;
 import com.esotericsoftware.yamlbeans.YamlConfig;
 import com.esotericsoftware.yamlbeans.YamlConfig.WriteClassName;
 import com.esotericsoftware.yamlbeans.YamlException;
@@ -134,6 +135,7 @@ public class YamlDocumentTest extends TestCase  {
 	@Test
 	public void testYamlSequenceIterator() throws YamlException {
 		YamlDocument yaml = readDocument("- 111\n- 222\n");
+		@SuppressWarnings("unchecked")
 		Iterator<YamlScalar> iterator = yaml.iterator();
 		assertEquals(true, iterator.hasNext());
 		YamlScalar yamlScalar = iterator.next();
@@ -152,6 +154,7 @@ public class YamlDocumentTest extends TestCase  {
 	@Test
 	public void testYamlMappingIterator() throws YamlException {
 		YamlDocument yaml = readDocument("name: Andi\nage: 18\n");
+		@SuppressWarnings("unchecked")
 		Iterator<YamlEntry> iterator = yaml.iterator();
 		assertEquals(true, iterator.hasNext());
 		YamlEntry yamlEntry = iterator.next();
@@ -164,6 +167,54 @@ public class YamlDocumentTest extends TestCase  {
 			iterator.next();
 			fail("Already read to the end.");
 		} catch (Exception e) {
+		}
+	}
+
+	@Test
+	public void testVersion1_0() throws YamlException {
+		String yaml = "version: !str 1.0";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml, new Version(1, 0));
+		YamlMapping yamlMapping = (YamlMapping) reader.read();
+		assertEquals("1.0", ((YamlScalar) yamlMapping.getEntry("version").getValue()).getValue());
+	}
+
+	@Test
+	public void testVersion1_0ThrowsYamlException() {
+		String yaml = "version: !!str 1.1";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml, new Version(1, 0));
+		try {
+			reader.read();
+			fail("1.0 Version tag is single '!'");
+		} catch (YamlException e) {
+		}
+	}
+
+	@Test
+	public void testVersion1_1() throws YamlException {
+		String yaml = "version: !!str 1.1";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml, new Version(1, 1));
+		YamlMapping yamlMapping = (YamlMapping) reader.read();
+		assertEquals("1.1", ((YamlScalar) yamlMapping.getEntry("version").getValue()).getValue());
+	}
+
+	@Test
+	public void testReadMultipleDocuments() throws YamlException {
+		String yaml = "key: 111\n---\nkey: 222";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml);
+		assertEquals(true, reader.read() != null);
+		assertEquals(true, reader.read() != null);
+		assertEquals(true, reader.read() == null);
+		assertEquals(true, reader.read() == null);
+	}
+
+	@Test
+	public void testReadThrowsYamlException() {
+		String yaml = "\tkey: value";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml);
+		try {
+			reader.read();
+			fail("Tabs cannot be used for indentation.");
+		} catch (YamlException e) {
 		}
 	}
 

--- a/test/com/esotericsoftware/yamlbeans/document/YamlMappingTest.java
+++ b/test/com/esotericsoftware/yamlbeans/document/YamlMappingTest.java
@@ -1,0 +1,136 @@
+package com.esotericsoftware.yamlbeans.document;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.esotericsoftware.yamlbeans.YamlException;
+
+public class YamlMappingTest {
+
+	private YamlMapping yamlMapping = null;
+
+	@Before
+	public void setUp() throws YamlException {
+		String yaml = "key1: value1\nkey2: value2\nkey3: value3\n";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml);
+		yamlMapping = (YamlMapping) reader.read();
+		yamlMapping.setAnchor("mapping");
+		yamlMapping.setTag("HashMap");
+	}
+
+	@Test
+	public void testSize() {
+		assertEquals(3, yamlMapping.size());
+	}
+
+	@Test
+	public void testAddEntry() throws YamlException {
+		YamlScalar key = new YamlScalar();
+		key.setValue("test");
+		YamlScalar value = new YamlScalar();
+		value.setValue("111");
+		YamlEntry entry = new YamlEntry(key, value);
+		yamlMapping.addEntry(entry);
+
+		assertEquals(entry, yamlMapping.getEntry("test"));
+	}
+
+	@Test
+	public void testDeleteEntry() {
+		assertEquals(true, yamlMapping.deleteEntry("key1"));
+		assertEquals(false, yamlMapping.deleteEntry("key4"));
+	}
+
+	@Test
+	public void testGetEntryByKey() throws YamlException {
+		assertEquals(true, yamlMapping.getEntry("key1") != null);
+		assertEquals(true, yamlMapping.getEntry("key4") == null);
+	}
+
+	@Test
+	public void testGetEntryByIndex() throws YamlException {
+		assertEquals(true, yamlMapping.getEntry(0) != null);
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void testGetEntryByIndexThrowsIndexOutOfBoundsException() throws YamlException {
+		yamlMapping.getEntry(3);
+	}
+
+	@Test
+	public void testToString() {
+		assertEquals("&mapping  !HashMap{key1:value1,key2:value2,key3:value3}", yamlMapping.toString());
+	}
+
+	@Test
+	public void testSetEntryUseBooleanValue() throws YamlException {
+		yamlMapping.setEntry("test", true);
+		assertEquals("true", ((YamlScalar) yamlMapping.getEntry("test").getValue()).getValue());
+	}
+
+	@Test
+	public void testSetEntryUseNumberValue() throws YamlException {
+		yamlMapping.setEntry("test", 1);
+		assertEquals("1", ((YamlScalar) yamlMapping.getEntry("test").getValue()).getValue());
+	}
+
+	@Test
+	public void testSetEntryUseStringValue() throws YamlException {
+		yamlMapping.setEntry("test", "test");
+		assertEquals("test", ((YamlScalar) yamlMapping.getEntry("test").getValue()).getValue());
+	}
+
+	@Test(expected = YamlException.class)
+	public void testGetElementByItemThrowsYamlException() throws YamlException {
+		yamlMapping.getElement(0);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testDeleteElementThrowsYamlException() throws YamlException {
+		yamlMapping.deleteElement(0);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetElementUseBooleanThrowsYamlException() throws YamlException {
+		yamlMapping.setElement(0, true);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetElementUseNumberThrowsYamlException() throws YamlException {
+		yamlMapping.setElement(0, 1);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetElementUseStringThrowsYamlException() throws YamlException {
+		yamlMapping.setElement(0, "test");
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetElementUseYamlElementThrowsYamlException() throws YamlException {
+		YamlElement YamlElement = new YamlScalar();
+		yamlMapping.setElement(0, YamlElement);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testAddElementUseBooleanThrowsYamlException() throws YamlException {
+		yamlMapping.addElement(true);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testAddElementUseNumberThrowsYamlException() throws YamlException {
+		yamlMapping.addElement(1);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testAddElementUseStringThrowsYamlException() throws YamlException {
+		yamlMapping.addElement("test");
+	}
+
+	@Test(expected = YamlException.class)
+	public void testAddElementUseYamlElementThrowsYamlException() throws YamlException {
+		YamlElement YamlElement = new YamlScalar();
+		yamlMapping.addElement(YamlElement);
+	}
+}

--- a/test/com/esotericsoftware/yamlbeans/document/YamlSequenceTest.java
+++ b/test/com/esotericsoftware/yamlbeans/document/YamlSequenceTest.java
@@ -1,0 +1,129 @@
+package com.esotericsoftware.yamlbeans.document;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.esotericsoftware.yamlbeans.YamlException;
+
+public class YamlSequenceTest {
+	private YamlSequence yamlSequence = null;
+
+	@Before
+	public void setUp() throws YamlException {
+		String yaml = "- 1\n- 2\n- 3\n";
+		YamlDocumentReader reader = new YamlDocumentReader(yaml);
+		yamlSequence = (YamlSequence) reader.read();
+		yamlSequence.setAnchor("sequence");
+		yamlSequence.setTag("LinkedList");
+	}
+
+	@Test
+	public void testSize() {
+		assertEquals(3, yamlSequence.size());
+	}
+
+	@Test
+	public void testAddElement() throws YamlException {
+		YamlElement yamlElement = new YamlScalar();
+		yamlSequence.addElement(yamlElement);
+		assertEquals(yamlElement, yamlSequence.getElement(3));
+	}
+
+	@Test
+	public void testDeleteElement() throws YamlException {
+		yamlSequence.deleteElement(0);
+		assertEquals(2, yamlSequence.size());
+	}
+
+	@Test
+	public void testToStrig() {
+		assertEquals("&sequence  !LinkedList[1,2,3]", yamlSequence.toString());
+	}
+
+	@Test(expected = YamlException.class)
+	public void testGetEntryByKeyThrowsYamlException() throws YamlException {
+		yamlSequence.getEntry("key");
+	}
+
+	@Test(expected = YamlException.class)
+	public void testGetEntryByIndexThrowsYamlException() throws YamlException {
+		yamlSequence.getEntry(0);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testDeleteEntryByKeyThrowsYamlException() throws YamlException {
+		yamlSequence.deleteEntry("key");
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetEntryUseBooleanValueThrowsYamlException() throws YamlException {
+		yamlSequence.setEntry("key", true);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetEntryUseNumberValueThrowsYamlException() throws YamlException {
+		yamlSequence.setEntry("key", 1);
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetEntryUseStringValueThrowsYamlException() throws YamlException {
+		yamlSequence.setEntry("key", "111");
+	}
+
+	@Test(expected = YamlException.class)
+	public void testSetEntryUseYamlElementValueThrowsYamlException() throws YamlException {
+		YamlElement yamlElement = new YamlScalar();
+		yamlSequence.setEntry("key", yamlElement);
+	}
+
+	@Test
+	public void testSetElementUseBooleanValue() throws YamlException {
+		yamlSequence.setElement(0, true);
+		YamlScalar yamlScalar = (YamlScalar) yamlSequence.getElement(0);
+		assertEquals("true", yamlScalar.getValue());
+	}
+
+	@Test
+	public void testSetElementUseNumberValue() throws YamlException {
+		yamlSequence.setElement(0, 1);
+		YamlScalar yamlScalar = (YamlScalar) yamlSequence.getElement(0);
+		assertEquals("1", yamlScalar.getValue());
+	}
+
+	@Test
+	public void testSetElementUseStringValue() throws YamlException {
+		yamlSequence.setElement(0, "testStr");
+		YamlScalar yamlScalar = (YamlScalar) yamlSequence.getElement(0);
+		assertEquals("testStr", yamlScalar.getValue());
+	}
+
+	@Test
+	public void testSetElementUseYamlElementValue() throws YamlException {
+		YamlElement yamlElement = new YamlScalar();
+		yamlSequence.setElement(0, yamlElement);
+		assertEquals(yamlElement, yamlSequence.getElement(0));
+	}
+
+	@Test
+	public void testAddElementUseBoolean() throws YamlException {
+		yamlSequence.addElement(true);
+		YamlScalar yamlScalar = (YamlScalar) yamlSequence.getElement(yamlSequence.size() - 1);
+		assertEquals("true", yamlScalar.getValue());
+	}
+
+	@Test
+	public void testAddElementUseNumber() throws YamlException {
+		yamlSequence.addElement(1);
+		YamlScalar yamlScalar = (YamlScalar) yamlSequence.getElement(yamlSequence.size() - 1);
+		assertEquals("1", yamlScalar.getValue());
+	}
+
+	@Test
+	public void testAddElementUseString() throws YamlException {
+		yamlSequence.addElement("testStr");
+		YamlScalar yamlScalar = (YamlScalar) yamlSequence.getElement(yamlSequence.size() - 1);
+		assertEquals("testStr", yamlScalar.getValue());
+	}
+}


### PR DESCRIPTION
- Modify `YamlDocumentReader.readDocument()` method to support reading multiple documents.
- Add unit test cases to improve code coverage.