### PR TITLE
fix bug

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
+++ b/src/com/esotericsoftware/yamlbeans/tokenizer/Tokenizer.java
@@ -945,7 +945,7 @@ public class Tokenizer {
 			chunks.append(prefixForward(length));
 			// forward(length);
 			spaces = scanPlainSpaces();
-			if (spaces == null || flowLevel == 0 && column < ind) break;
+			if (spaces.length() == 0 || flowLevel == 0 && column < ind) break;
 		}
 		return new ScalarToken(chunks.toString(), true);
 	}

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -538,4 +538,23 @@ public class YamlReaderTest extends TestCase {
         reader = new YamlReader(stringWithSpaceAndTab);
         assertEquals(stringWithSpaceAndTab, reader.read(String.class));
     }
+
+	/**
+	 * Test multiple documents, the document is a scalar, followed by "---" or
+	 * "...", the test read is normal.
+	 *
+	 * @throws YamlException
+	 */
+	public void testReadMultiTpyeDocuments() throws YamlException {
+		String yaml = "scalar\n---\nkey: value\n---\nscalar\n...\n";
+		YamlReader reader = new YamlReader(yaml);
+		String str = reader.read(String.class);
+		assertEquals("scalar", str);
+
+		Map<String, String> map = (Map<String, String>) reader.read(HashMap.class);
+		assertEquals("value", map.get("key"));
+
+		str = reader.read(String.class);
+		assertEquals("scalar", str);
+	}
 }


### PR DESCRIPTION
948 lines of `Tokenizer.java class`, the judgment condition is wrong.

Can't read this yaml, yaml = "scalar\n---\nkey: value\n---\nscalar\n...\n".
Before modification, the result of read is "{scalar--- key:value}\n", the first document read error.
