### PR TITLE
write version and tags

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/Version.java
+++ b/src/com/esotericsoftware/yamlbeans/Version.java
@@ -31,11 +31,13 @@ public class Version {
 		if (dotIndex == -1) throw new IllegalArgumentException("value must contain a period: " + value);
 		major = Integer.parseInt(value.substring(0, dotIndex));
 		minor = Integer.parseInt(value.substring(dotIndex + 1));
+		check();
 	}
 
 	public Version (int major, int minor) {
 		this.major = major;
 		this.minor = minor;
+		check();
 	}
 
 	public String toString () {
@@ -62,5 +64,10 @@ public class Version {
 		if (major != other.major) return false;
 		if (minor != other.minor) return false;
 		return true;
+	}
+
+	private void check() {
+		if (major != 1) throw new IllegalArgumentException("major must be 1.");
+		if (minor < 0 || minor > 1) throw new IllegalArgumentException("minor must be 0 or 1.");
 	}
 }

--- a/src/com/esotericsoftware/yamlbeans/YamlConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlConfig.java
@@ -140,6 +140,8 @@ public class YamlConfig {
 		boolean keepBeanPropertyOrder = false;
 		WriteClassName writeClassName = WriteClassName.AUTO;
 		Quote quote = Quote.NONE;
+		Version version;
+		Map<String,String> tags;
 		EmitterConfig emitterConfig = new EmitterConfig();
 
 		WriteConfig () {
@@ -193,7 +195,12 @@ public class YamlConfig {
 
 		/** Sets the YAML version to output. Default is 1.1. */
 		public void setVersion (Version version) {
-			emitterConfig.setVersion(version);
+			this.version = version;
+		}
+
+		/** Sets the YAML tags to output. */
+		public void setTags(Map<String, String> tags) {
+			this.tags = tags;
 		}
 
 		/** If true, the YAML output will be canonical. Default is false. */

--- a/src/com/esotericsoftware/yamlbeans/YamlWriter.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlWriter.java
@@ -92,7 +92,8 @@ public class YamlWriter {
 				emitter.emit(Event.STREAM_START);
 				started = true;
 			}
-			emitter.emit(new DocumentStartEvent(config.writeConfig.explicitFirstDocument, null, null));
+			emitter.emit(new DocumentStartEvent(config.writeConfig.explicitFirstDocument, config.writeConfig.version,
+					config.writeConfig.tags));
 			isRoot = true;
 			writeValue(object, config.writeConfig.writeRootTags ? null : object.getClass(), null, null);
 			emitter.emit(new DocumentEndEvent(config.writeConfig.explicitEndDocument));

--- a/src/com/esotericsoftware/yamlbeans/emitter/Emitter.java
+++ b/src/com/esotericsoftware/yamlbeans/emitter/Emitter.java
@@ -144,7 +144,7 @@ public class Emitter {
 							throw new EmitterException("Unsupported YAML version: " + documentStartEvent.version);
 						writer.writeVersionDirective(documentStartEvent.version.toString());
 					}
-					if ((documentStartEvent.version != null && documentStartEvent.version.equals(1, 0)) || config.version.equals(1, 0)) {
+					if ((documentStartEvent.version != null && documentStartEvent.version.equals(1, 0))) {
 						isVersion10 = true;
 						tagPrefixes = new HashMap(DEFAULT_TAG_PREFIXES_1_0);
 					} else

--- a/src/com/esotericsoftware/yamlbeans/emitter/EmitterConfig.java
+++ b/src/com/esotericsoftware/yamlbeans/emitter/EmitterConfig.java
@@ -16,22 +16,13 @@
 
 package com.esotericsoftware.yamlbeans.emitter;
 
-import com.esotericsoftware.yamlbeans.Version;
-
 /** @author <a href="mailto:misc@n4te.com">Nathan Sweet</a> */
 public class EmitterConfig {
-	Version version = new Version(1, 1);
 	boolean canonical;
 	boolean useVerbatimTags = true;
 	int indentSize = 3;
 	int wrapColumn = 100;
 	boolean escapeUnicode = true;
-
-	/** Sets the YAML version to output. Default is 1.1. */
-	public void setVersion (Version version) {
-		if (version == null) throw new IllegalArgumentException("version cannot be null.");
-		this.version = version;
-	}
 
 	/** If true, the YAML output will be canonical. Default is false. */
 	public void setCanonical (boolean canonical) {


### PR DESCRIPTION
When supplementing unit test cases, it was found that the `EmitterWriter.writeVersionDirective()` and `EmitterWriter.writeTagDirective()` methods were not called.

Read the code and made a little modification to support the output of YAMl version and YAML tags.

Unit test cases will be added later.