### PR TITLE
Remove the redundant commas

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/emitter/Emitter.java
+++ b/src/com/esotericsoftware/yamlbeans/emitter/Emitter.java
@@ -216,7 +216,6 @@ public class Emitter {
 					indent = indents.remove(0);
 					flowLevel--;
 					if (config.canonical) {
-						writer.writeIndicator(",", false, false, false);
 						writer.writeIndent(indent);
 					}
 					writer.writeIndicator("]", false, false, false);
@@ -270,7 +269,6 @@ public class Emitter {
 					indent = indents.remove(0);
 					flowLevel--;
 					if (config.canonical) {
-						writer.writeIndicator(",", false, false, false);
 						writer.writeIndent(indent);
 					}
 					writer.writeIndicator("}", false, false, false);

--- a/test/com/esotericsoftware/yamlbeans/YamlConfigTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlConfigTest.java
@@ -365,12 +365,37 @@ public class YamlConfigTest {
 
 	@Test
 	public void testSetCanonical() throws YamlException {
+		int indentSize = 3;
+		yamlConfig.writeConfig.setIndentSize(indentSize);
 		yamlConfig.writeConfig.setCanonical(true);
 		StringWriter stringWriter = new StringWriter();
 		YamlWriter yamlWriter = new YamlWriter(stringWriter, yamlConfig);
 		yamlWriter.write("test");
 		yamlWriter.close();
 		assertEquals("--- " + LINE_SEPARATOR + "!java.lang.String \"test\"" + LINE_SEPARATOR, stringWriter.toString());
+
+		List<String> list = new ArrayList<String>();
+		list.add("111");
+		list.add("222");
+		stringWriter = new StringWriter();
+		yamlWriter = new YamlWriter(stringWriter, yamlConfig);
+		yamlWriter.write(list);
+		yamlWriter.close();
+		assertEquals("--- " + LINE_SEPARATOR + "[" + LINE_SEPARATOR + multipleSpaces(indentSize)
+				+ "!java.lang.String \"111\"," + LINE_SEPARATOR + multipleSpaces(indentSize)
+				+ "!java.lang.String \"222\"" + LINE_SEPARATOR + "]" + LINE_SEPARATOR, stringWriter.toString());
+
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("key", "value");
+		stringWriter = new StringWriter();
+		yamlWriter = new YamlWriter(stringWriter, yamlConfig);
+		yamlWriter.write(map);
+		yamlWriter.close();
+		assertEquals(
+				"--- " + LINE_SEPARATOR + "{" + LINE_SEPARATOR + multipleSpaces(indentSize)
+						+ "? !java.lang.String \"key\"" + LINE_SEPARATOR + multipleSpaces(indentSize)
+						+ ": !java.lang.String \"value\"" + LINE_SEPARATOR + "}" + LINE_SEPARATOR,
+				stringWriter.toString());
 	}
 
 	@Test
@@ -386,7 +411,7 @@ public class YamlConfigTest {
 		yamlWriter.write(list);
 		yamlWriter.close();
 		assertEquals("--- " + LINE_SEPARATOR + "[" + LINE_SEPARATOR + multipleSpaces(indentSize)
-				+ "!java.lang.Integer \"1\"," + LINE_SEPARATOR + "]" + LINE_SEPARATOR, stringWriter.toString());
+				+ "!java.lang.Integer \"1\"" + LINE_SEPARATOR + "]" + LINE_SEPARATOR, stringWriter.toString());
 
 		try {
 			yamlConfig.writeConfig.setIndentSize(1);


### PR DESCRIPTION
When set `yamlConfig. WriteConfig. SetCanonical (true)`, YamlWriter serializes the List and Map, and the last element has a comma, which is redundant.

The test code:
```java
@Test
public void test010() throws YamlException {
	List<String> list = new ArrayList<>();
	list.add("111");
	list.add("222");
	list.add("333");

	Map<String, String> map = new HashMap<String, String>();
	map.put("name", "Jack");
	map.put("age", "3");

	StringWriter sw = new StringWriter();
	YamlConfig yamlConfig = new YamlConfig();
	yamlConfig.writeConfig.setCanonical(true);
	YamlWriter yamlWriter = new YamlWriter(sw, yamlConfig);
	yamlWriter.write(list);
	yamlWriter.write(map);
	yamlWriter.close();

	System.out.println(sw.toString());
}
```
Console output:
```
--- 
[
   !java.lang.String "111",
   !java.lang.String "222",
   !java.lang.String "333",
]
--- 
{
   ? !java.lang.String "name"
   : !java.lang.String "Jack",
   ? !java.lang.String "age"
   : !java.lang.String "3",
}

```
And YamlReader deserialization failed.
