### PR TITLE
Restoration logic

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/Beans.java
+++ b/src/com/esotericsoftware/yamlbeans/Beans.java
@@ -184,7 +184,7 @@ class Beans {
 				}
 			}
 			if (getMethod != null && (setMethod != null || constructorProperty)) {
-				property = new MethodProperty(name, setMethod, getMethod);
+				return new MethodProperty(name, setMethod, getMethod);
 			}
 		}
 


### PR DESCRIPTION
When I looked at PR #130 , I found that the previous logic was inconsistent.

When beanProperties is true, "Property = new MethodProperty(name, setMethod, getMethod)", the property may continue to be assigned to" Property = new FieldProperty(field)", inconsistent with the previous code logic.