### PR TITLE
Anchor and Alias

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -96,6 +96,7 @@ public class YamlReader {
 	/** Reads an array, Map, List, or Collection object of the specified type from YAML, using the specified element type.
 	 * @param type The type of object to read. If null, behaves the same as {{@link #read()}. */
 	public <T> T read (Class<T> type, Class elementType) throws YamlException {
+		anchors.clear();
 		try {
 			while (true) {
 				Event event = parser.getNextEvent();

--- a/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlReaderTest.java
@@ -635,6 +635,19 @@ public class YamlReaderTest extends TestCase {
 		assertEquals(123, ((Long) reader.get("1")).intValue());
 	}
 
+	public void testAnchorAndAlias() throws YamlException {
+		String yaml = "key: &1 value\nkey1: *1\n---\nkey: *1";
+		YamlReader reader = new YamlReader(yaml);
+		assertEquals("value", ((Map<String, String>) reader.read()).get("key1"));
+		assertEquals("value", reader.get("1"));
+
+		try {
+			reader.read();
+		} catch (YamlReaderException e) {
+			assertTrue(e.getMessage().contains("Unknown anchor: "));
+		}
+	}
+
 	public void testReadExpectExpectThrowsParserException() {
 		String yaml = "[1,2,3";
 		YamlReader reader = new YamlReader(yaml);


### PR DESCRIPTION
According to the [Alias Nodes](https://yaml.org/spec/1.1/#id902561) section in YAML, The anchor should only be valid for the current document.
