### PR TITLE
Add test case to improve the YamlWriter line coverage

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlWriter.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlWriter.java
@@ -104,11 +104,6 @@ public class YamlWriter {
 		}
 	}
 
-	/** Returns the YAML emitter, which allows the YAML output to be configured. */
-	public Emitter getEmitter () {
-		return emitter;
-	}
-
 	/** Writes any buffered objects, then resets the list of anchored objects.
 	 * @see WriteConfig#setAutoAnchor(boolean) */
 	public void clearAnchors () throws YamlException {

--- a/test/com/esotericsoftware/yamlbeans/YamlConfigTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlConfigTest.java
@@ -198,15 +198,16 @@ public class YamlConfigTest {
 		YamlWriter yamlWriter = new YamlWriter(stringWriter, yamlConfig);
 		Map<String, String> map = new HashMap<String, String>();
 		map.put("a", "111");
-		map.put("btag", "222");
+		map.put("atag", "!222");
 		yamlWriter.write(map);
 		yamlWriter.close();
 
+		assertEquals("a: !222 111" + LINE_SEPARATOR, stringWriter.toString());
+
+		yamlConfig.setClassTag("!222", String.class);
 		YamlReader yamlReader = new YamlReader(stringWriter.toString(), yamlConfig);
 		Map<String, String> result = yamlReader.read(Map.class);
-		assertTrue(result.containsKey("a"));
-		assertFalse(result.containsKey("btag"));
-		assertTrue(result.containsKey("atag"));
+		assertEquals(map.toString(), result.toString());
 	}
 
 	@Test

--- a/test/com/esotericsoftware/yamlbeans/YamlWriterTest.java
+++ b/test/com/esotericsoftware/yamlbeans/YamlWriterTest.java
@@ -24,6 +24,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -307,6 +308,23 @@ public class YamlWriterTest extends TestCase {
 		object.file = new File("some/path/andFile.txt");
 		ClassWithFile roundTrip = roundTrip(object, ClassWithFile.class, config);
 		assertEquals(object.file, roundTrip.file);
+	}
+
+	public void testSetAlias() throws YamlException {
+		Map<String, Test> map = new LinkedHashMap<String, Test>();
+		Test test = new Test();
+		test.stringValue = "test";
+		map.put("key1", test);
+		map.put("key2", test);
+
+		StringWriter sw = new StringWriter();
+		YamlWriter yamlWriter = new YamlWriter(sw);
+		yamlWriter.setAlias(test, "t");
+		yamlWriter.write(map);
+		yamlWriter.close();
+		assertEquals("!java.util.LinkedHashMap" + LINE_SEPARATOR
+				+ "key1: &t !com.esotericsoftware.yamlbeans.YamlWriterTest$Test" + LINE_SEPARATOR
+				+ "   stringValue: test" + LINE_SEPARATOR + "key2: *t" + LINE_SEPARATOR, sw.toString());
 	}
 
 	private Object roundTrip (Object object) throws Exception {


### PR DESCRIPTION
- Add and modify unit test cases to improve `YamlWriter` line coverage;

- Delete the unused `getEmitter` method so that the user doesn't have to get YAML Emitter and doesn't know how to use YAML Emitter.