### PR TITLE
Refactor Parser and YamlReader

### DIFF
--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -49,7 +49,7 @@ import com.esotericsoftware.yamlbeans.tokenizer.Tokenizer.TokenizerException;
 public class YamlReader implements AutoCloseable {
 	private final YamlConfig config;
 	Parser parser;
-	private final Map<String, Object> anchors = new HashMap();
+	private final Map<String, Object> anchorMap = new HashMap();
 
 	public YamlReader (Reader reader) {
 		this(reader, new YamlConfig());
@@ -75,16 +75,16 @@ public class YamlReader implements AutoCloseable {
 	/** Return the object with the given alias, or null. This is only valid after objects have been read and before
 	 * {@link #close()} */
 	public Object get (String alias) {
-		return anchors.get(alias);
+		return anchorMap.get(alias);
 	}
 
 	private void addAnchor (String key, Object value) {
-		if (config.readConfig.anchors) anchors.put(key, value);
+		if (config.readConfig.anchors) anchorMap.put(key, value);
 	}
 
 	public void close () throws IOException {
 		parser.close();
-		anchors.clear();
+		anchorMap.clear();
 	}
 
 	/** Reads the next YAML document and deserializes it into an object. The type of object is defined by the YAML tag. If there is
@@ -107,7 +107,7 @@ public class YamlReader implements AutoCloseable {
 	 * @param type The type of object to read. If null, behaves the same as {{@link #read()}.
 	 * @throws YamlReaderException if the YAML data specifies a type that is incompatible with the specified type. */
 	public <T> T read (Class<T> type, Class elementType) throws YamlException {
-		anchors.clear();
+		anchorMap.clear();
 		try {
 			while (true) {
 				Event event = parser.getNextEvent();
@@ -160,7 +160,7 @@ public class YamlReader implements AutoCloseable {
 		case ALIAS:
 			parser.getNextEvent();
 			anchor = ((AliasEvent)event).anchor;
-			Object value = anchors.get(anchor);
+			Object value = anchorMap.get(anchor);
 			if (value == null && config.readConfig.anchors) throw new YamlReaderException("Unknown anchor: " + anchor);
 			return value;
 		case MAPPING_START:

--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -49,7 +49,7 @@ import com.esotericsoftware.yamlbeans.tokenizer.Tokenizer.TokenizerException;
 public class YamlReader implements AutoCloseable {
 	private final YamlConfig config;
 	Parser parser;
-	private final Map<String, Object> anchorMap = new HashMap();
+	private final Map<String, Object> anchors = new HashMap();
 
 	public YamlReader (Reader reader) {
 		this(reader, new YamlConfig());
@@ -75,16 +75,16 @@ public class YamlReader implements AutoCloseable {
 	/** Return the object with the given alias, or null. This is only valid after objects have been read and before
 	 * {@link #close()} */
 	public Object get (String alias) {
-		return anchorMap.get(alias);
+		return anchors.get(alias);
 	}
 
 	private void addAnchor (String key, Object value) {
-		if (config.readConfig.anchors) anchorMap.put(key, value);
+		if (config.readConfig.anchors) anchors.put(key, value);
 	}
 
 	public void close () throws IOException {
 		parser.close();
-		anchorMap.clear();
+		anchors.clear();
 	}
 
 	/** Reads the next YAML document and deserializes it into an object. The type of object is defined by the YAML tag. If there is
@@ -107,7 +107,7 @@ public class YamlReader implements AutoCloseable {
 	 * @param type The type of object to read. If null, behaves the same as {{@link #read()}.
 	 * @throws YamlReaderException if the YAML data specifies a type that is incompatible with the specified type. */
 	public <T> T read (Class<T> type, Class elementType) throws YamlException {
-		anchorMap.clear();
+		anchors.clear();
 		try {
 			while (true) {
 				Event event = parser.getNextEvent();
@@ -160,7 +160,7 @@ public class YamlReader implements AutoCloseable {
 		case ALIAS:
 			parser.getNextEvent();
 			anchor = ((AliasEvent)event).anchor;
-			Object value = anchorMap.get(anchor);
+			Object value = anchors.get(anchor);
 			if (value == null && config.readConfig.anchors) throw new YamlReaderException("Unknown anchor: " + anchor);
 			return value;
 		case MAPPING_START:

--- a/src/com/esotericsoftware/yamlbeans/YamlReader.java
+++ b/src/com/esotericsoftware/yamlbeans/YamlReader.java
@@ -288,7 +288,7 @@ public class YamlReader implements AutoCloseable {
 				if (config.readConfig.guessNumberTypes) {
 					String value = ((ScalarEvent)event).value;
 					if (value != null) {
-						Number number = valueConvertedNumber(value);
+						Number number = parseNumber(value);
 						if (number != null) {
 							if (anchor != null) addAnchor(anchor, number);
 							parser.getNextEvent();
@@ -503,7 +503,7 @@ public class YamlReader implements AutoCloseable {
 		}
 	}
 
-	private Number valueConvertedNumber (String value) {
+	private Number parseNumber(String value) {
 		Number number = null;
 		try {
 			number = Long.decode(value);

--- a/src/com/esotericsoftware/yamlbeans/parser/Parser.java
+++ b/src/com/esotericsoftware/yamlbeans/parser/Parser.java
@@ -127,15 +127,24 @@ public class Parser {
 		};
 		table[P_IMPLICIT_DOCUMENT] = new Production() {
 			public Event produce () {
-				TokenType type = tokenizer.peekNextTokenType();
-				if (!(type == DIRECTIVE || type == DOCUMENT_START || type == STREAM_END)) {
-					parseStack.add(0, table[P_DOCUMENT_END]);
-					parseStack.add(0, table[P_BLOCK_NODE]);
-					parseStack.add(0, table[P_DOCUMENT_START_IMPLICIT]);
+				if (isNextTokenImplicitDocument()) {
+					parseImplicitDocument();
 				}
 				return null;
 			}
+
+			private boolean isNextTokenImplicitDocument() {
+				TokenType type = tokenizer.peekNextTokenType();
+				return type != DIRECTIVE && type != DOCUMENT_START && type != STREAM_END;
+			}
+
+			private void parseImplicitDocument() {
+				parseStack.add(0, table[P_DOCUMENT_END]);
+				parseStack.add(0, table[P_BLOCK_NODE]);
+				parseStack.add(0, table[P_DOCUMENT_START_IMPLICIT]);
+			}
 		};
+
 		table[P_EXPLICIT_DOCUMENT] = new Production() {
 			public Event produce () {
 				if (tokenizer.peekNextTokenType() != STREAM_END) {


### PR DESCRIPTION
After looking through the codebase, I was impressed by the code coverage and thought it was pretty amazing.

I made the decision to refactor certain small portions because I wanted to contribute to the project.

This PR refactors some methods of the Parser and YamlReader classes.

### Parser
##### Decompose type conditional for implicit document in `initProductionTable`

- The `produce()` method calls the helper method `isNextTokenImplicitDocument()` to check if the next token indicates an implicit document. This makes the condition clearer and easier to understand.

- The `isNextTokenImplicitDocument()` method encapsulates the condition logic, making it self-explanatory.

- If the condition is met, the `parseImplicitDocument()` method is called, which contains the logic for adding items to the parse stack. This separates concerns and improves code readability.

### YamlReader
##### Rename method `valueConvertedNumber()` to `parseNumber()`
- The method valueConvertedNumber has been renamed to parseNumber for improved clarity and consistency with naming conventions.

- Enhances the readability of the codebase and better reflects the purpose of the method, which is to parse a string value into a Number object.

##### Extract method `readScalarValue()` from `readValueInternal()`
- Extract the deserialization of scalar values into a new method.
- Increases modularity of readValueInternal.
- Improved the documentation by adding Javadoc for the `readScalarValue()` method.

---
### Checklist
Checklist I followed before raising the PR.
- [x] Build the project
- [x] Run the tests after the refactor

<img width="975" alt="Screenshot 2024-03-16 at 2 06 48 PM" src="https://github.com/EsotericSoftware/yamlbeans/assets/29810455/d1b57f29-5e7b-4908-be25-826d100edda2">
